### PR TITLE
fix(cli): Load user application only in the worker

### DIFF
--- a/cli/src/pipeless_ai_cli/commands/run.py
+++ b/cli/src/pipeless_ai_cli/commands/run.py
@@ -26,8 +26,10 @@ def run_app(component: str):
 
     app_filename = 'app.py'
     app_path = os.path.join(exec_dir, app_filename)
-    if not os.path.exists(app_path):
-        rprint("[red]Unable to find app.py file, are you running the command from your application directory?[/red]")
-        sys.exit(1)
+    if component in ['worker', 'all']:
+        # We only load the application into the worker
+        if not os.path.exists(app_path):
+            rprint("[red]Unable to find app.py file, are you running the command from your application directory?[/red]")
+            sys.exit(1)
 
     Pipeless(config, component, app_path)


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).
 -->

### Description of the change

This PR makes the CLI to check the existence of the user `app.py` only when using the worker, since input and output do not require it. 

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
