### PR TITLE
feat(kv_store): Add KV store

### DIFF
--- a/pipeless/Cargo.lock
+++ b/pipeless/Cargo.lock
@@ -255,6 +255,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-epoch"
+version = "0.9.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +411,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +507,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -866,6 +898,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,12 +1282,37 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -1308,7 +1374,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeless-ai"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "clap",
  "env_logger",
@@ -1317,6 +1383,7 @@ dependencies = [
  "gstreamer",
  "gstreamer-app",
  "json_to_table",
+ "lazy_static",
  "log",
  "ndarray",
  "numpy",
@@ -1327,6 +1394,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "sled",
  "tokio",
  "tokio-stream",
  "uuid",
@@ -1404,7 +1472,7 @@ dependencies = [
  "indoc",
  "libc",
  "memoffset",
- "parking_lot",
+ "parking_lot 0.12.1",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -1499,6 +1567,15 @@ name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1797,6 +1874,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "sled"
+version = "0.34.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
+dependencies = [
+ "crc32fast",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "fs2",
+ "fxhash",
+ "libc",
+ "log",
+ "parking_lot 0.11.2",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,7 +2077,7 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot",
+ "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.5",

--- a/pipeless/Cargo.toml
+++ b/pipeless/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pipeless-ai"
-version = "1.0.2"
+version = "1.1.0"
 edition = "2021"
 authors = ["Miguel A. Cabrera Minagorri"]
 description = "An open-source computer vision framework to build and deploy applications in minutes"
@@ -40,6 +40,8 @@ clap = { version = "4.4.7", features = ["derive"] }
 reqwest = { version = "0.11.22", features = ["blocking", "json"] }
 openssl = { version = "0.10", features = ["vendored"] }
 json_to_table = "0.6.0"
+sled = "0.34.7"
+lazy_static = "1.4.0"
 
 [dependencies.uuid]
 version = "1.4.1"

--- a/pipeless/src/data.rs
+++ b/pipeless/src/data.rs
@@ -16,6 +16,7 @@ pub struct RgbFrame {
     input_ts: std::time::Instant, // to measure processing performance
     inference_input: ndarray::ArrayBase<ndarray::OwnedRepr<f32>, ndarray::Dim<ndarray::IxDynImpl>>,
     inference_output: ndarray::ArrayBase<ndarray::OwnedRepr<f32>, ndarray::Dim<ndarray::IxDynImpl>>,
+    pipeline_id: uuid::Uuid,
 }
 impl RgbFrame {
     pub fn new(
@@ -23,6 +24,7 @@ impl RgbFrame {
         width: usize, height: usize,
         pts: gst::ClockTime, dts: gst::ClockTime, duration: gst::ClockTime,
         fps: u8, input_ts: std::time::Instant,
+        pipeline_id: uuid::Uuid,
     ) -> Self {
         let modified = original.to_owned();
         RgbFrame {
@@ -33,6 +35,7 @@ impl RgbFrame {
             input_ts,
             inference_input: ndarray::ArrayBase::zeros(ndarray::IxDyn(&[1])),
             inference_output: ndarray::ArrayBase::zeros(ndarray::IxDyn(&[1])),
+            pipeline_id,
         }
     }
 
@@ -45,6 +48,7 @@ impl RgbFrame {
         fps: u8, input_ts: u64,
         inference_input: ndarray::ArrayBase<ndarray::OwnedRepr<f32>, ndarray::Dim<ndarray::IxDynImpl>>,
         inference_output: ndarray::ArrayBase<ndarray::OwnedRepr<f32>, ndarray::Dim<ndarray::IxDynImpl>>,
+        pipeline_id: &str,
     ) -> Self {
         RgbFrame {
             uuid: uuid::Uuid::from_str(uuid).unwrap(),
@@ -55,7 +59,8 @@ impl RgbFrame {
             duration: gst::ClockTime::from_mseconds(duration),
             fps,
             input_ts: std::time::Instant::now() - std::time::Duration::from_millis(input_ts),
-            inference_input, inference_output
+            inference_input, inference_output,
+            pipeline_id: uuid::Uuid::from_str(pipeline_id).unwrap(),
         }
     }
 
@@ -118,6 +123,12 @@ impl RgbFrame {
     pub fn set_inference_output(&mut self, output_data: ndarray::ArrayBase<ndarray::OwnedRepr<f32>, ndarray::Dim<ndarray::IxDynImpl>>) {
         self.inference_output = output_data;
     }
+    pub fn get_pipeline_id(&self) -> uuid::Uuid {
+        self.pipeline_id
+    }
+    pub fn set_pipeline_id(&mut self, pipeline_id: &str) {
+        self.pipeline_id = uuid::Uuid::from_str(pipeline_id).unwrap();
+    }
 }
 
 pub enum Frame {
@@ -129,11 +140,12 @@ impl Frame {
         width: usize, height: usize,
         pts: gst::ClockTime, dts: gst::ClockTime, duration: gst::ClockTime,
         fps: u8, input_ts: std::time::Instant,
+        pipeline_id: uuid::Uuid
     ) -> Self {
         let rgb = RgbFrame::new(
             original, width, height,
             pts, dts, duration,
-            fps, input_ts
+            fps, input_ts, pipeline_id
         );
         Self::RgbFrame(rgb)
     }

--- a/pipeless/src/kvs/mod.rs
+++ b/pipeless/src/kvs/mod.rs
@@ -1,0 +1,1 @@
+pub mod store;

--- a/pipeless/src/kvs/store.rs
+++ b/pipeless/src/kvs/store.rs
@@ -1,0 +1,61 @@
+use log::error;
+use sled;
+use lazy_static::lazy_static;
+
+// We assume the type implementing StoreInterface can be send thread safely
+pub trait StoreInterface: Sync {
+    fn get(&self, key: &str) -> String;
+    fn set(&self, key: &str, value: &str);
+}
+
+struct LocalStore {
+    backend: sled::Db,
+}
+impl LocalStore {
+    fn new() -> Self {
+        let db_path = "/tmp/.pipeless_kv_store";
+        let db = sled::open(db_path).expect("Failed to open KV store");
+        Self { backend: db }
+    }
+}
+impl StoreInterface for LocalStore {
+    /// Insert a KV pair, logs an error if it fails, but do not stop the program.
+    /// Trying to get the key will return an empty string.
+    fn set(&self, key: &str, value: &str) {
+        if let Err(err) = self.backend.insert(key, value) {
+            error!("Error inserting key {} with value {} in local KV store. Error: {}", key, value, err);
+        }
+    }
+
+    /// Returns the value or an empty string
+    fn get(&self, key: &str) -> String {
+        match self.backend.get(key) {
+            Ok(v) => {
+                match v.as_deref() {
+                    Some(v) => std::str::from_utf8(v).unwrap().into(),
+                    None => String::from("")
+                }
+            },
+            Err(err) => {
+                error!("Error getting value for key {} from local KV store. Error: {}", key, err);
+                String::from("")
+            }
+        }
+    }
+}
+
+// TODO: setup Redis or any other distributed solution.
+// Important: Note that any type implementing StoreInterface must be thread safe
+struct DistributedStore {}
+impl DistributedStore {
+    fn new() -> Self { unimplemented!() }
+}
+impl StoreInterface for DistributedStore {
+    fn get(&self, key: &str) -> String { unimplemented!() }
+    fn set(&self, key: &str, value: &str) { unimplemented!() }
+}
+
+lazy_static! {
+    // TODO: Add support for distributed store do not hardcode the local one
+    pub static ref KV_STORE: Box<dyn StoreInterface> = Box::new(LocalStore::new());
+}

--- a/pipeless/src/lib.rs
+++ b/pipeless/src/lib.rs
@@ -19,3 +19,4 @@ pub mod data;
 pub mod dispatcher;
 pub mod stages;
 pub mod cli;
+pub mod kvs;

--- a/pipeless/src/stages/languages/python.rs
+++ b/pipeless/src/stages/languages/python.rs
@@ -159,7 +159,7 @@ import {0}
 def hook_wrapper(frame, context):
     pipeline_id = frame['pipeline_id']
     def pipeless_kvs_set(key, value):
-        _pipeless_kvs_set(f'{1}:{{pipeline_id}}:{{key}}', value)
+        _pipeless_kvs_set(f'{1}:{{pipeline_id}}:{{key}}', str(value))
     def pipeless_kvs_get(key):
         return _pipeless_kvs_get(f'{1}:{{pipeline_id}}:{{key}}')
     {0}.pipeless_kvs_set = pipeless_kvs_set


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).
 -->

### Description of the change

This PR adds a KV store that can be used to share data between frames.

The user can call `pipeless_kvs_set` and `pipeless_kvs_get` to set and get KV pairs.

The internal keys are automatically converted to the format `stage_name:pipeline_id:user_key` to avoid conflicts when running multiple streams and multiple stages per stream.

Finally, the `pipeless_kvs_get` function will return an empty value by default, including when the key does not exist. Since frames are executed in parallel, a key could not exist at the time of getting it, users need to take this into account.
The `pipeless_kvs_set` function converts any value to string before inserting it into the store.


<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #71 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
