### PR TITLE
fix(frame): Initialize dynamic arrays empty instead of with zeros

### DIFF
--- a/pipeless/Cargo.lock
+++ b/pipeless/Cargo.lock
@@ -1374,7 +1374,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeless-ai"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "clap",
  "env_logger",

--- a/pipeless/Cargo.toml
+++ b/pipeless/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pipeless-ai"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 authors = ["Miguel A. Cabrera Minagorri"]
 description = "An open-source computer vision framework to build and deploy applications in minutes"

--- a/pipeless/src/data.rs
+++ b/pipeless/src/data.rs
@@ -33,8 +33,8 @@ impl RgbFrame {
             width, height,
             pts, dts, duration, fps,
             input_ts,
-            inference_input: ndarray::ArrayBase::zeros(ndarray::IxDyn(&[1])),
-            inference_output: ndarray::ArrayBase::zeros(ndarray::IxDyn(&[1])),
+            inference_input: ndarray::ArrayBase::zeros(ndarray::IxDyn(&[0])),
+            inference_output: ndarray::ArrayBase::zeros(ndarray::IxDyn(&[0])),
             pipeline_id,
         }
     }


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).
 -->

### Description of the change

The dynamic arrays for `inference_input` and `inference_output` were initialized with a single element with a zero, not allowing to check if the array is empty from a hook.
This PR changes that to initialize them without any values (`[]`)


<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Allows user hooks to check if the `inference_input` and/or `inference_output` arrays are empty.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
