### PR TITLE
fix: Improve error handling

### DIFF
--- a/pipeless/Cargo.lock
+++ b/pipeless/Cargo.lock
@@ -1374,7 +1374,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeless-ai"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "clap",
  "env_logger",

--- a/pipeless/Cargo.toml
+++ b/pipeless/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pipeless-ai"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2021"
 authors = ["Miguel A. Cabrera Minagorri"]
 description = "An open-source computer vision framework to build and deploy applications in minutes"

--- a/pipeless/src/config/adapters/rest.rs
+++ b/pipeless/src/config/adapters/rest.rs
@@ -32,7 +32,7 @@ async fn handle_add_stream(
     stream: StreamBody,
     streams_table: Arc<RwLock<pipeless::config::streams::StreamsTable>>,
     dispatcher_sender: tokio::sync::mpsc::UnboundedSender<pipeless::dispatcher::DispatcherEvent>
-) -> Result<warp::reply::WithStatus<warp::reply::Json>, String> {
+) -> Result<warp::reply::WithStatus<warp::reply::Json>, Infallible> {
     let input_uri: String;
     if let Some(uri) = stream.clone().input_uri {
         input_uri = uri;
@@ -58,7 +58,10 @@ async fn handle_add_stream(
             .add(pipeless::config::streams::StreamsTableEntry::new(input_uri, output_uri, frame_path));
 
         if let Err(err) = res {
-            return Err(format!("Error adding new stream to the table: {}", err));
+            return Ok(warp::reply::with_status(
+                warp::reply::json(&json!({"error": format!("Error adding new stream to the table: {}", err)})),
+                warp::http::StatusCode::INTERNAL_SERVER_ERROR,
+            ));
         }
     }
 

--- a/pipeless/src/config/video.rs
+++ b/pipeless/src/config/video.rs
@@ -34,9 +34,9 @@ impl Video {
             let uri_split: Vec<&str> = uri.split("://").collect();
             protocol = uri_split.get(0).ok_or_else(|| { VideoConfigError::new("Unable to get protocol from URI") })?.to_string();
             location = uri_split.get(1)
-                .ok_or_else(|| { VideoConfigError::new("Unable to get location from URI. Ensure it contains the protocol followed by '//'.") })?.to_string();
+                .ok_or_else(|| { VideoConfigError::new("Unable to get location from URI. Ensure it contains the protocol followed by '://'. Example: file:///home/user/file.mp4") })?.to_string();
             if protocol == "file" && !location.starts_with('/') {
-                panic!("When using files you should indicate an absolute path. Ensure your path is on the format file:///some/path (note there are 3 slashes)");
+                panic!("When using files you should indicate an absolute path. Ensure your path is on the format file:///home/user/file.mp4 (note there are 3 slashes)");
             }
         } else {
             protocol = String::from("v4l2");

--- a/pipeless/src/data.rs
+++ b/pipeless/src/data.rs
@@ -69,14 +69,8 @@ impl RgbFrame {
     pub fn get_original_pixels(&self) -> &ndarray::Array3<u8> {
         &self.original
     }
-    pub fn get_owned_original_pixels(&self) -> ndarray::Array3<u8> {
-        self.original.to_owned()
-    }
     pub fn get_modified_pixels(&self) -> &ndarray::Array3<u8> {
         &self.modified
-    }
-    pub fn get_owned_modified_pixels(&self) -> ndarray::Array3<u8> {
-        self.modified.to_owned()
     }
     pub fn get_mutable_pixels(&mut self) -> ndarray::ArrayViewMut3<u8> {
         self.modified.view_mut()

--- a/pipeless/src/kvs/store.rs
+++ b/pipeless/src/kvs/store.rs
@@ -14,7 +14,8 @@ struct LocalStore {
 impl LocalStore {
     fn new() -> Self {
         let db_path = "/tmp/.pipeless_kv_store";
-        let db = sled::open(db_path).expect("Failed to open KV store");
+        let db = sled::open(db_path)
+            .expect(&format!("Failed to open KV store. Ensure pipeless can write at {}", db_path));
         Self { backend: db }
     }
 }
@@ -46,6 +47,7 @@ impl StoreInterface for LocalStore {
 
 // TODO: setup Redis or any other distributed solution.
 // Important: Note that any type implementing StoreInterface must be thread safe
+/*
 struct DistributedStore {}
 impl DistributedStore {
     fn new() -> Self { unimplemented!() }
@@ -54,6 +56,7 @@ impl StoreInterface for DistributedStore {
     fn get(&self, key: &str) -> String { unimplemented!() }
     fn set(&self, key: &str, value: &str) { unimplemented!() }
 }
+*/
 
 lazy_static! {
     // TODO: Add support for distributed store do not hardcode the local one

--- a/pipeless/src/stages/languages/python.rs
+++ b/pipeless/src/stages/languages/python.rs
@@ -1,6 +1,6 @@
 use log::{error, warn};
 use pyo3::prelude::*;
-use numpy::{self, ToPyArray};
+use numpy;
 
 use crate::{data::{RgbFrame, Frame}, stages::{hook::HookTrait, stage::ContextTrait}, stages::stage::Context, kvs::store};
 

--- a/pipeless/src/stages/languages/python.rs
+++ b/pipeless/src/stages/languages/python.rs
@@ -29,8 +29,8 @@ impl IntoPy<Py<PyAny>> for RgbFrame {
     fn into_py(self, py: Python) -> Py<PyAny> {
         let dict = pyo3::types::PyDict::new(py);
         dict.set_item("uuid", self.get_uuid().to_string()).unwrap();
-        dict.set_item("original", numpy::PyArray3::from_owned_array(py, self.get_owned_original_pixels())).unwrap();
-        dict.set_item("modified", numpy::PyArray3::from_owned_array(py, self.get_owned_modified_pixels())).unwrap();
+        dict.set_item("original", numpy::PyArray3::from_array(py, self.get_original_pixels())).unwrap();
+        dict.set_item("modified", numpy::PyArray3::from_array(py, self.get_modified_pixels())).unwrap();
         dict.set_item("width", self.get_width()).unwrap();
         dict.set_item("height", self.get_height()).unwrap();
         dict.set_item("pts", self.get_pts().mseconds()).unwrap();
@@ -38,8 +38,8 @@ impl IntoPy<Py<PyAny>> for RgbFrame {
         dict.set_item("duration", self.get_duration().mseconds()).unwrap();
         dict.set_item("fps", self.get_fps()).unwrap();
         dict.set_item("input_ts", self.get_input_ts()).unwrap();
-        dict.set_item("inference_input", self.get_inference_input().to_owned().to_pyarray(py)).unwrap();
-        dict.set_item("inference_output", self.get_inference_output().to_owned().to_pyarray(py)).unwrap();
+        dict.set_item("inference_input", numpy::PyArrayDyn::from_array(py, self.get_inference_input())).unwrap();
+        dict.set_item("inference_output", numpy::PyArrayDyn::from_array(py, self.get_inference_output())).unwrap();
         dict.set_item("pipeline_id", self.get_pipeline_id().to_string()).unwrap();
         dict.into()
     }


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).
 -->

### Description of the change

This PR improves error handling by avoiding the use of `panic` and `expect`  during streams processing. This avoids Pipeless to crash on an error, showing the error and continuing with the processing of any other possible stream.

This is specially necessary for production deployment.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
