### PR TITLE
fix(rest api): listen in 0.0.0.0 by default

### DIFF
--- a/pipeless/src/config/adapters/rest.rs
+++ b/pipeless/src/config/adapters/rest.rs
@@ -278,7 +278,7 @@ impl RestAdapter {
             .or(remove_stream);
 
         let server = warp::serve(streams_endpoint)
-            .run(([127, 0, 0, 1], 3030));
+            .run(([0, 0, 0, 0], 3030));
 
         info!("REST adapter running");
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).
 -->

### Description of the change

Listening in `127.0.0.1` does not allow for external connections while `0.0.0.0`does.
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
