### PR TITLE
feat: Add stream restart policy

### DIFF
--- a/pipeless/Cargo.lock
+++ b/pipeless/Cargo.lock
@@ -1436,7 +1436,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeless-ai"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "clap",
  "env_logger",

--- a/pipeless/Cargo.toml
+++ b/pipeless/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pipeless-ai"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 authors = ["Miguel A. Cabrera Minagorri"]
 description = "An open-source computer vision framework to build and deploy applications in minutes"

--- a/pipeless/src/cli/streams.rs
+++ b/pipeless/src/cli/streams.rs
@@ -23,7 +23,12 @@ fn handle_response(response: Result<reqwest::blocking::Response, reqwest::Error>
     }
 }
 
-pub fn add(input_uri: &str, output_uri: &Option<String>, frame_path: &str) {
+pub fn add(
+    input_uri: &str,
+    output_uri: &Option<String>,
+    frame_path: &str,
+    restart_policy: &Option<String>,
+) {
     let url = "http://localhost:3030/streams";
 
     let stages_vec: Vec<&str> = frame_path.split(",").collect();
@@ -31,6 +36,7 @@ pub fn add(input_uri: &str, output_uri: &Option<String>, frame_path: &str) {
         "input_uri": input_uri,
         "output_uri": output_uri,
         "frame_path": stages_vec,
+        "restart_policy": restart_policy,
     });
 
     let client = reqwest::blocking::Client::new();
@@ -60,7 +66,8 @@ pub fn update(
     stream_id: &str,
     input_uri: &Option<String>,
     output_uri: &Option<String>,
-    frame_path: &Option<String>
+    frame_path: &Option<String>,
+    restart_policy: &Option<String>,
 ) {
     let url = "http://localhost:3030/streams";
 
@@ -78,6 +85,7 @@ pub fn update(
         "input_uri": input_uri,
         "output_uri": output_uri,
         "frame_path": stages_vec,
+        "restart_policy": restart_policy,
     });
 
     let client = reqwest::blocking::Client::new();

--- a/pipeless/src/config/adapters/rest.rs
+++ b/pipeless/src/config/adapters/rest.rs
@@ -5,7 +5,7 @@ use serde_json::json;
 use warp::Filter;
 use serde_derive::{Deserialize, Serialize};
 
-use crate::{self as pipeless, config::streams::RestartPolicy};
+use crate as pipeless;
 
 #[derive(Clone, Deserialize, Serialize)]
 struct StreamBody {
@@ -57,7 +57,7 @@ async fn handle_add_stream(
         Some(policy) => policy,
         None => {
             warn!("Restart policy not specified for stream, defaulting to 'never'");
-            RestartPolicy::Never
+            pipeless::config::streams::RestartPolicy::Never
         }
     };
     {
@@ -147,7 +147,7 @@ async fn handle_update_stream(
             ));
         }
     }
-    let restart_policy: RestartPolicy;
+    let restart_policy: pipeless::config::streams::RestartPolicy;
     if let Some(policy) = stream.clone().restart_policy {
         restart_policy = policy;
     } else {

--- a/pipeless/src/config/streams.rs
+++ b/pipeless/src/config/streams.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::collections::hash_map::DefaultHasher;
 use std::str::FromStr;
-use log::{error, info};
+use log::{error, warn};
 use serde_derive::{Serialize, Deserialize};
 use uuid;
 
@@ -129,8 +129,10 @@ impl StreamsTableEntry {
             None => false
         };
         if using_input_file || using_output_file {
-            info!("Overriding restart policy with 'never' because the stream uses files");
-            restart_policy = RestartPolicy::Never;
+            if restart_policy != RestartPolicy::Never {
+                warn!("Overriding restart policy with 'never' because the stream uses files");
+                restart_policy = RestartPolicy::Never;
+            }
         }
 
         Self {

--- a/pipeless/src/dispatcher.rs
+++ b/pipeless/src/dispatcher.rs
@@ -4,7 +4,7 @@ use tokio::sync::RwLock;
 use log::{warn, error, info};
 use tokio;
 
-use crate::{self as pipeless, config::streams::StreamEntryState};
+use crate as pipeless;
 
 pub enum DispatcherEvent {
     TableChange, // Indicates a change on the config table. Adapters notify changes via this
@@ -122,8 +122,8 @@ pub fn start(
                             let entries_without_pipeline: Vec<&pipeless::config::streams::StreamsTableEntry> =
                                 streams_table_copy.iter().filter(without_pipeline).collect();
                             for entry in entries_without_pipeline {
-                                error!("{:?}", entry.get_target_state());
-                                if entry.get_target_state() != StreamEntryState::Running {
+                                if entry.get_target_state() != pipeless::config::streams::StreamEntryState::Running {
+                                    // Skip the creation of pipelines for streams whose target state is not running
                                     continue;
                                 }
                                 let dispatcher_event_sender = dispatcher_sender.clone();
@@ -233,7 +233,6 @@ pub fn start(
 
                             return;
                         }
-
 
                         // Create new event since we have modified the streams config table
                         if let Err(err) = dispatcher_sender.send(DispatcherEvent::TableChange) {

--- a/pipeless/src/main.rs
+++ b/pipeless/src/main.rs
@@ -21,6 +21,9 @@ enum AddCommand {
         /// Comma separated list of stages that will be executed for the frames of the new stream
         #[arg(short, long)]
         frame_path: String,
+        /// Optional. Restart policy for the stream. Either always, never, on_error or on_eos. on_eos by default.
+        #[arg(short, long)]
+        restart_policy: Option<String>,
     }
 }
 
@@ -50,6 +53,9 @@ enum UpdateCommand {
         /// Optional. New comma separated list of stages that will be executed for the frames of the new stream
         #[arg(short, long)]
         frame_path: Option<String>,
+        /// Optional. Restart policy for the stream. Either always, never, on_error or on_eos.
+        #[arg(short, long)]
+        restart_policy: Option<String>,
     }
 }
 
@@ -97,7 +103,6 @@ enum Commands {
     },
 }
 
-
 fn main() {
     let cli = Cli::parse();
 
@@ -106,7 +111,7 @@ fn main() {
         Some(Commands::Start { stages_dir }) => pipeless_ai::cli::start::start_pipeless_node(&stages_dir),
         Some(Commands::Add { command }) => {
             match &command {
-                Some(AddCommand::Stream { input_uri, output_uri, frame_path }) => pipeless_ai::cli::streams::add(input_uri, output_uri, frame_path),
+                Some(AddCommand::Stream { input_uri, output_uri, frame_path , restart_policy}) => pipeless_ai::cli::streams::add(input_uri, output_uri, frame_path, restart_policy),
                 None =>  println!("Use --help to see the complete list of available commands"),
             }
         },
@@ -118,7 +123,7 @@ fn main() {
         },
         Some(Commands::Update { command }) => {
             match &command {
-                Some(UpdateCommand::Stream { id, input_uri, output_uri, frame_path }) => pipeless_ai::cli::streams::update(id, input_uri, output_uri, frame_path),
+                Some(UpdateCommand::Stream { id, input_uri, output_uri, frame_path , restart_policy}) => pipeless_ai::cli::streams::update(id, input_uri, output_uri, frame_path, restart_policy),
                 None =>  println!("Use --help to see the complete list of available commands"),
             }
         },

--- a/pipeless/src/main.rs
+++ b/pipeless/src/main.rs
@@ -21,7 +21,7 @@ enum AddCommand {
         /// Comma separated list of stages that will be executed for the frames of the new stream
         #[arg(short, long)]
         frame_path: String,
-        /// Optional. Restart policy for the stream. Either always, never, on_error or on_eos. on_eos by default.
+        /// Optional. Restart policy for the stream. Either always, never, on_error or on_eos. 'Never' by default.
         #[arg(short, long)]
         restart_policy: Option<String>,
     }

--- a/pipeless/src/stages/hook.rs
+++ b/pipeless/src/stages/hook.rs
@@ -65,6 +65,7 @@ impl StatefulHook {
 /// frames are waiting for the lock to be released, however, in the stateless case, we can safely access the
 /// content of the hook from many frames at the same time. It is up to the user to elect when to use each one
 /// Note Stateless hooks use Arc while Stateful use Arc_Mutex
+/// Note also that distributing the computing for stateful hooks in a cloud setup may be a bad idea.
 #[derive(Clone)] // Cloning will not duplicate data since we are using Arc
 pub enum Hook {
     StatelessHook(StatelessHook),


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).
 -->

### Description of the change

This PR adds support for the `restart_policy` option. The restart policy allows to specify when the processing of a stream should be restarted, including `error`, `eos`, `never` or `always`. 

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
