### PR TITLE
fix: cleanup KV store when pipeline ends

### DIFF
--- a/pipeless/Cargo.lock
+++ b/pipeless/Cargo.lock
@@ -1493,7 +1493,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeless-ai"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "clap",
  "env_logger",

--- a/pipeless/Cargo.toml
+++ b/pipeless/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pipeless-ai"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 authors = ["Miguel A. Cabrera Minagorri"]
 description = "An open-source computer vision framework to build and deploy applications in minutes"

--- a/pipeless/src/stages/languages/python.rs
+++ b/pipeless/src/stages/languages/python.rs
@@ -154,6 +154,7 @@ impl PythonHook {
         let module_file_name = format!("{}.py", module_name);
         let wrapper_module_name = format!("{}_wrapper", module_name);
         let wrapper_module_file_name = format!("{}.py", wrapper_module_name);
+        // NOTE: We prepend the keys with the pipeline id and the stage name. The stage avoids key collision when you import a stage from the hub. We set the pipeline_id first to make it easier to cleanup when a stream ends
         // TODO: create a KVS module for python using PYo3 and expose it via pyo3::append_to_inittab!(make_person_module); so users can import it on their hooks
         let wrapper_py_code = format!("
 import {0}
@@ -161,9 +162,9 @@ import {0}
 def hook_wrapper(frame, context):
     pipeline_id = frame['pipeline_id']
     def pipeless_kvs_set(key, value):
-        _pipeless_kvs_set(f'{1}:{{pipeline_id}}:{{key}}', str(value))
+        _pipeless_kvs_set(f'{{pipeline_id}}:{1}:{{key}}', str(value))
     def pipeless_kvs_get(key):
-        return _pipeless_kvs_get(f'{1}:{{pipeline_id}}:{{key}}')
+        return _pipeless_kvs_get(f'{{pipeline_id}}:{1}:{{key}}')
     {0}.pipeless_kvs_set = pipeless_kvs_set
     {0}.pipeless_kvs_get = pipeless_kvs_get
     {0}.hook(frame, context)


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).
 -->

### Description of the change

This PR takes care of cleaning up the KV store when a stream ends. The cleanup was missing in previous versions.
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
