### PR TITLE
fix: stream hash differs  when stage includes '-'

### DIFF
--- a/pipeless/src/config/streams.rs
+++ b/pipeless/src/config/streams.rs
@@ -118,9 +118,10 @@ impl StreamsTableEntry {
         frame_path: Vec<String>,
         restart_policy: RestartPolicy,
     ) -> Self {
-        let entry_hash = calculate_entry_hash(&input_uri, output_uri.as_deref(), &frame_path, &restart_policy);
         // We have to use underscores when providing the stage names as modules to some laguages like Python.
         let sanitized_frame_path: Vec<String> = frame_path.iter().map(|s| s.replace("-", "_")).collect();
+
+        let entry_hash = calculate_entry_hash(&input_uri, output_uri.as_deref(), &sanitized_frame_path, &restart_policy);
 
         let mut restart_policy = restart_policy;
         let using_input_file = input_uri.starts_with("file://");
@@ -194,8 +195,8 @@ impl StreamsTableEntry {
         calculate_entry_hash(
             self.get_input_uri(),
             self.get_output_uri(),
-            &self.frame_path,
-            &self.restart_policy,
+            self.get_frame_path(),
+            &self.get_restart_policy()
         )
     }
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).
 -->

### Description of the change

Fix restart loop when using multistreams and stages that contain `-` in the name 

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits



<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #111 
