### PR TITLE
feat: Allow source camera selection

### DIFF
--- a/pipeless/Cargo.lock
+++ b/pipeless/Cargo.lock
@@ -1483,7 +1483,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeless-ai"
-version = "1.5.4"
+version = "1.6.0"
 dependencies = [
  "clap",
  "env_logger",

--- a/pipeless/Cargo.toml
+++ b/pipeless/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pipeless-ai"
-version = "1.5.4"
+version = "1.6.0"
 edition = "2021"
 authors = ["Miguel A. Cabrera Minagorri"]
 description = "An open-source computer vision framework to build and deploy applications in minutes"

--- a/pipeless/src/config/video.rs
+++ b/pipeless/src/config/video.rs
@@ -30,7 +30,7 @@ impl Video {
             // Output to the screen
             protocol = String::from("screen");
             location = String::from("screen");
-        } else if uri != "v4l2" {
+        } else if !uri.starts_with("v4l2") {
             let uri_split: Vec<&str> = uri.split("://").collect();
             protocol = uri_split.get(0).ok_or_else(|| { VideoConfigError::new("Unable to get protocol from URI") })?.to_string();
             location = uri_split.get(1)


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).
 -->

### Description of the change

This PR adds support for selecting the device when using `v4l2` in the form `v4l2:/dev/videoX`. For example: `--input-uri v4l2:/dev/video0`

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #117 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
