### PR TITLE
Allow duplicated input URIs

### DIFF
--- a/pipeless/src/config/streams.rs
+++ b/pipeless/src/config/streams.rs
@@ -270,16 +270,6 @@ impl StreamsTable {
     }
 
     pub fn add(&mut self, entry: StreamsTableEntry) -> Result<(), String> {
-        if self.table.iter().any(|e| e.input_uri == entry.input_uri) {
-            return Err("Duplicated input_uri".to_string());
-        }
-        if let Some(ref output_uri) = entry.output_uri {
-            // When the output is to the screen we allow the duplication
-            if output_uri != "screen" && self.table.iter().any(|e| e.output_uri == Some(output_uri.clone())) {
-                return Err("Duplicated output_uri".to_string());
-            }
-        }
-
         self.table.push(entry);
         Ok(())
     }


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).
 -->

### Description of the change

This PR removes the restriction of using unique input URIs. There is no real reason for not allow duplicated URIs and sometimes it is even required if you want to process the same stream with two different execution paths
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
