### PR TITLE
fix(container): Use base image with CUDA 11.7 for TensorRT

### DIFF
--- a/package/Dockerfile-tensorrt
+++ b/package/Dockerfile-tensorrt
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/tensorrt:23.08-py3
+FROM nvcr.io/nvidia/tensorrt:22.12-py3
 
 COPY scripts/install_packages /usr/bin/install_packages
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).
 -->

### Description of the change

The TensorRT image was using a base image with CUDA 12, producing an error because the ONNX runtime was unable to find the CUDA 11 libraries. This PR fixes the problem by using a base image that ships CUDA 11.7, which is also consistent with the CUDA container image.

- fixes https://github.com/pipeless-ai/pipeless/discussions/124

